### PR TITLE
Allow user preferences for Fast Forward / Reverse speeds

### DIFF
--- a/flowblade-trunk/Flowblade/editorpersistance.py
+++ b/flowblade-trunk/Flowblade/editorpersistance.py
@@ -175,9 +175,11 @@ def update_prefs_from_widgets(widgets_tuples_tuple):
     default_profile_combo, open_in_last_opened_check, open_in_last_rendered_check, undo_max_spin, load_order_combo = gen_opts_widgets
     
     # Jul-2016 - SvdB - Added play_pause_button
+    # Apr-2017 - SvdB - Added ffwd / rev values
     auto_play_in_clip_monitor_check, auto_center_check, grfx_insert_length_spin, \
         trim_exit_click, trim_quick_enter, remember_clip_frame, overwrite_clip_drop, cover_delete, \
-        play_pause_button, mouse_scroll_action, hide_file_ext_button, auto_center_on_updown = edit_prefs_widgets
+        play_pause_button, mouse_scroll_action, hide_file_ext_button, auto_center_on_updown, \
+        ffwd_rev_shift, ffwd_rev_ctrl, ffwd_rev_caps = edit_prefs_widgets
     
     use_english, disp_splash, buttons_style, dark_theme, theme_combo, audio_levels_combo, window_mode_combo, full_names = view_prefs_widgets
 
@@ -203,6 +205,10 @@ def update_prefs_from_widgets(widgets_tuples_tuple):
     prefs.play_pause = play_pause_button.get_active()
     prefs.hide_file_ext = hide_file_ext_button.get_active()
     prefs.mouse_scroll_action_is_zoom = (mouse_scroll_action.get_active() == 0)
+    # Apr-2017 - SvdB - ffwd / rev values
+    prefs.ffwd_rev_shift = int(ffwd_rev_shift.get_adjustment().get_value())
+    prefs.ffwd_rev_ctrl = int(ffwd_rev_ctrl.get_adjustment().get_value())
+    prefs.ffwd_rev_caps = int(ffwd_rev_caps.get_adjustment().get_value())
     
     prefs.use_english_always = use_english.get_active()
     prefs.display_splash_screen = disp_splash.get_active()
@@ -303,3 +309,8 @@ class EditorPreferences:
         # Feb-2017 - SvdB - for full file names
         self.show_full_file_names = False
         self.center_on_arrow_move = False
+        # Apr-2017 - SvdB - Using these values we maintain the original hardcoded speed
+        self.ffwd_rev_shift = 1
+        self.ffwd_rev_ctrl = 10
+        self.ffwd_rev_caps = 1
+

--- a/flowblade-trunk/Flowblade/keyevents.py
+++ b/flowblade-trunk/Flowblade/keyevents.py
@@ -166,6 +166,10 @@ def _handle_tline_key_event(event):
     Returns True for handled key presses to stop those
     keyevents from going forward.
     """
+    
+    # Apr-2017 - SvdB - For ffwd / rev speeds
+    prefs = editorpersistance.prefs
+
     # I
     if event.keyval == Gdk.KEY_i:
         if (event.get_state() & Gdk.ModifierType.MOD1_MASK):
@@ -310,6 +314,26 @@ def _handle_tline_key_event(event):
                  monitorevent.down_arrow_seek_on_monitor_clip()
                  return True
             
+        # Apr-2017 - SvdB - Add different speeds for different modifiers
+        # Allow user to select what speed belongs to what modifier, knowing that a combo of mods
+        # will MULTIPLY all speeds
+        # Available: SHIFT_MASK META_MASK - There are others available but it is not clear what the mappings
+        # for these keys are.
+        # For now: Harcoding = SHIFT = 2x, CTRL = 5x, CapsLock = 4x
+        if event.keyval == Gdk.KEY_Left or event.keyval == Gdk.KEY_Right:
+            if event.keyval == Gdk.KEY_Left:
+                seek_amount = -1
+            else:
+                seek_amount = 1
+            if (event.get_state() & Gdk.ModifierType.SHIFT_MASK):
+                seek_amount = seek_amount * prefs.ffwd_rev_shift
+            if (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+                seek_amount = seek_amount * prefs.ffwd_rev_ctrl
+            if (event.get_state() & Gdk.ModifierType.LOCK_MASK):
+                seek_amount = seek_amount * prefs.ffwd_rev_caps
+            PLAYER().seek_delta(seek_amount)
+            return True
+        """ Commented out for ffwd / rev speed
         # LEFT ARROW, prev frame
         if event.keyval == Gdk.KEY_Left:
             if (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
@@ -325,7 +349,7 @@ def _handle_tline_key_event(event):
             else:
                 PLAYER().seek_delta(1)
             return True
-            
+        """    
         # T
         if event.keyval == Gdk.KEY_t:
             tlineaction.three_point_overwrite_pressed()
@@ -499,6 +523,29 @@ def _handle_clip_key_event(event):
     # Key bindings for MOVE MODES
     if editorstate.current_is_move_mode():                  
         # LEFT ARROW, prev frame
+        # Apr-2017 - SvdB - Add different speeds for different modifiers
+        # Allow user to select what speed belongs to what modifier, knowing that a combo of mods
+        # will MULTIPLY all speeds
+        # Available: SHIFT_MASK META_MASK - There are others available but it is not clear what the mappings
+        # for these keys are.
+        # For now: Harcoding = SHIFT = 2x, CTRL = 5x, CapsLock = 4x
+        
+        prefs = editorpersistance.prefs
+        if event.keyval == Gdk.KEY_Left or event.keyval == Gdk.KEY_Right:
+            if event.keyval == Gdk.KEY_Left:
+                seek_amount = -1
+            else:
+                seek_amount = 1
+            if (event.get_state() & Gdk.ModifierType.SHIFT_MASK):
+                seek_amount = seek_amount * prefs.ffwd_rev_shift
+            if (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+                seek_amount = seek_amount * prefs.ffwd_rev_ctrl
+            if (event.get_state() & Gdk.ModifierType.LOCK_MASK):
+                seek_amount = seek_amount * prefs.ffwd_rev_caps
+            PLAYER().seek_delta(seek_amount)
+            return True
+        """ Commented out for ffwd / rev speed   
+        # LEFT ARROW, prev frame
         if event.keyval == Gdk.KEY_Left:
             if (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
                 PLAYER().seek_delta(-10)
@@ -513,8 +560,8 @@ def _handle_clip_key_event(event):
             else:
                 PLAYER().seek_delta(1)
             return True
-
-         # UP ARROW
+        """
+        # UP ARROW
         if event.keyval == Gdk.KEY_Up:
             if editorstate.timeline_visible():
                 tline_frame = PLAYER().tracktor_producer.frame()

--- a/flowblade-trunk/Flowblade/preferenceswindow.py
+++ b/flowblade-trunk/Flowblade/preferenceswindow.py
@@ -207,6 +207,31 @@ def _edit_prefs_panel():
     auto_center_on_updown = Gtk.CheckButton()
     auto_center_on_updown.set_active(prefs.center_on_arrow_move)
     
+    # Apr-2017 - SvdB - For FF/Rev speed options
+    if hasattr(prefs, 'ffwd_rev_shift'):
+        spin_adj = Gtk.Adjustment(prefs.ffwd_rev_shift, 1, 10, 1)
+    else:
+        spin_adj = Gtk.Adjustment(1, 1, 10, 1)
+    ffwd_rev_shift_spin = Gtk.SpinButton()
+    ffwd_rev_shift_spin.set_adjustment(spin_adj)
+    ffwd_rev_shift_spin.set_numeric(True)
+
+    if hasattr(prefs, 'ffwd_rev_ctrl'):
+        spin_adj = Gtk.Adjustment(prefs.ffwd_rev_ctrl, 1, 10, 1)
+    else:
+        spin_adj = Gtk.Adjustment(10, 1, 10, 1)
+    ffwd_rev_ctrl_spin = Gtk.SpinButton()
+    ffwd_rev_ctrl_spin.set_adjustment(spin_adj)
+    ffwd_rev_ctrl_spin.set_numeric(True)
+    
+    if hasattr(prefs, 'ffwd_rev_caps'):
+        spin_adj = Gtk.Adjustment(prefs.ffwd_rev_caps, 1, 10, 1)
+    else:
+        spin_adj = Gtk.Adjustment(1, 1, 10, 1)
+    ffwd_rev_caps_spin = Gtk.SpinButton()
+    ffwd_rev_caps_spin.set_adjustment(spin_adj)
+    ffwd_rev_caps_spin.set_numeric(True)
+    
     # Layout
     row1 = _row(guiutils.get_checkbox_row_box(auto_play_in_clip_monitor, Gtk.Label(label=_("Autoplay new Clips in Clip Monitor"))))
     row2 = _row(guiutils.get_checkbox_row_box(auto_center_on_stop, Gtk.Label(label=_("Center Current Frame on Playback Stop"))))
@@ -221,6 +246,17 @@ def _edit_prefs_panel():
     row10 = _row(guiutils.get_checkbox_row_box(play_pause_button, Gtk.Label(label=_("Enable single Play/Pause button"))))
     row11 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Mouse Middle Button Scroll Action")), mouse_scroll_action, PREFERENCES_LEFT))
     row12 = _row(guiutils.get_checkbox_row_box(hide_file_ext_button, Gtk.Label(label=_("Hide file extensions when importing Clips"))))
+    # Apr-2017 - SvdB - For Fast Forward / Reverse options
+    row14 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Fast Forward / Reverse Speed for Shift Key:")), ffwd_rev_shift_spin, PREFERENCES_LEFT))
+    row14.set_tooltip_text(_("Speed of Forward / Reverse will be multiplied by this value if Shift Key is held (Only using KEYS).\n" \
+        "Enabling multiple modifier keys will multiply the set values.\n" \
+        "E.g. if Shift is set to " + str(prefs.ffwd_rev_shift) + " and Ctrl to " + str(prefs.ffwd_rev_ctrl) + \
+        ", holding Shift + Ctrl will result in up to " + str(prefs.ffwd_rev_shift * prefs.ffwd_rev_ctrl) + "x speed.\n" \
+        "(Effective maximum speed depends on underlying software and/or hardware limitations)"))
+    row15 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Fast Forward / Reverse Speed for Control Key:")), ffwd_rev_ctrl_spin, PREFERENCES_LEFT))
+    row15.set_tooltip_text(_("Speed of Forward / Reverse will be multiplied by this value if Ctrl Key is held (Only using KEYS)."))
+    row16 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Fast Forward / Reverse Speed for Caps Lock Key:")), ffwd_rev_caps_spin, PREFERENCES_LEFT))
+    row16.set_tooltip_text(_("Speed of Forward / Reverse will be multiplied by this value if Caps Lock is set (Only using KEYS)."))
     
     vbox = Gtk.VBox(False, 2)
     vbox.pack_start(row5, False, False, 0)
@@ -236,14 +272,20 @@ def _edit_prefs_panel():
     vbox.pack_start(row10, False, False, 0)
     vbox.pack_start(row11, False, False, 0)
     vbox.pack_start(row12, False, False, 0)
+    # Apr-2017 - SvdB - For ffwd / rev speed
+    vbox.pack_start(row14, False, False, 0)
+    vbox.pack_start(row15, False, False, 0)
+    vbox.pack_start(row16, False, False, 0)
     vbox.pack_start(Gtk.Label(), True, True, 0)
 
     guiutils.set_margins(vbox, 12, 0, 12, 12)
 
     # Jul-2016 - SvdB - Added play_pause_button
+    # Apr-2017 - SvdB - Added ffwd / rev values
     return vbox, (auto_play_in_clip_monitor, auto_center_on_stop, gfx_length_spin,
                   trim_exit_on_empty, quick_enter_trim, remember_clip_frame, overwrite_clip_drop, cover_delete,
-                  play_pause_button, mouse_scroll_action, hide_file_ext_button, auto_center_on_updown)
+                  play_pause_button, mouse_scroll_action, hide_file_ext_button, auto_center_on_updown,
+                  ffwd_rev_shift_spin, ffwd_rev_ctrl_spin, ffwd_rev_caps_spin)
 
 def _view_prefs_panel():
     prefs = editorpersistance.prefs


### PR DESCRIPTION
Instead of the hardcoded 10x speed for Ffwd / Rev add user preferences to set the speed (1..10) on each of these keys: Shift, Ctrl, CapsLock (NB: Use of Alt or Meta would need remapping as standard assignment of Alt+Ctrl + Left (Or Right arrow) is to move to another workspace, so it was easiest to use CapsLock as a third modifier)
The user can set each of the modifiers to 1..10 and the resulting Ffwd / Rev speeds is the multiplication of the values (limited by software / hardware restrictions, though).
This allows fine control of Ffwd / Rev speeds by combining Right / Left arrow and Shift or Shift + Ctrl or just Ctrl or any of the 3 keys set up.
It speeds up scanning through the clips (Or the project timeline) tremendously.